### PR TITLE
expose the text representation of errors inside a bundled error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 *.py[cod]
 
+# Miscellaneous System Files
+*.DS_Store
+
 # C extensions
 *.so
 

--- a/cronutils/error_handler.py
+++ b/cronutils/error_handler.py
@@ -76,7 +76,7 @@ class ErrorHandler():
                 self.errors[traceback] = [self.data]
         return True
     
-    def raise_errors(self):
+    def __repr__(self):
         output = ""
         if self.descriptor:
             output += "*** %s ***\n" % self.descriptor
@@ -86,10 +86,16 @@ class ErrorHandler():
             output += traceback
             if any(errors):
                 output += "%s\n" % errors[:self.data_limit]
-            output += "===============\n\n\n"
+            output += "===============\n"
+        return output
+    
+    def raise_errors(self):
+        output = self.__repr__()
         if self.errors:
             stderr.write(output)
+            stderr.write("\n\n")
             raise BundledError()
+
 
 class NullErrorHandler():
     def __init__(self, descriptor=None, data_limit=100):


### PR DESCRIPTION
Moved the text output generation out of raise_errors and into a __repr__ function.
Printing bundled error objects directly now has a useful representation.
The bundled error text representation can now be extracted for use outside of cronic.