### PR TITLE
Sentry throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,63 @@ TASKS = {
 
 ...
 ```
+# Kill Times
+
+The time limit of tasks specified in TIME_LIMITS is for emailing you about tasks that take longer than expected to run.
+If a task takes over four times the time limit (see MAX_TIME_MULTIPLIER), the process of that task is killed. You can
+specify your own custom kill time by passing in param `kill_time` to `run_tasks`. For example, here is an alternate
+`cron.py` that specifies custom kill times:
+
+```python
+from sys import argv
+from cronutils import run_tasks
+
+FIVE_MINUTES = "five_minutes"
+HOURLY = "hourly"
+FOUR_HOURLY = "four_hourly"
+DAILY = "daily"
+WEEKLY = "weekly"
+MONTHLY = "monthly"
+
+TASKS = {
+    FIVE_MINUTES: [],
+    HOURLY: [],
+    FOUR_HOURLY: [],
+    DAILY: [],
+    WEEKLY: [],
+    MONTHLY: [],
+}
+
+TIME_LIMITS = {
+    FIVE_MINUTES: 180, # 3 minutes
+    HOURLY: 3600,      # 60 minutes
+    FOUR_HOURLY: 5400, # 1.5 hours
+    DAILY: 43200,      # 12 hours
+    WEEKLY: 86400,     # 1 day
+    MONTHLY: 259200,   # 3 days
+}
+
+KILL_TIMES = {
+    FIVE_MINUTES: 300, # 5 minutes
+    HOURLY: 3600, # 1 hour
+}
+
+
+if __name__ == "__main__":
+    if len(argv) <= 1:
+        raise Exception("Not enough arguments to cron\n")
+    elif argv[1] in TASKS:
+        cron_type = argv[1]
+        if cron_type in KILL_TIMES:
+            run_tasks(TASKS[cron_type], TIME_LIMITS[cron_type], cron_type, KILL_TIMES[cron_type])
+        else:
+            run_tasks(TASKS[cron_type], TIME_LIMITS[cron_type], cron_type)
+    else:
+        raise Exception("Invalid argument to cron\n")
+```
+
+
+
 
 # Error Aggregation
 
@@ -168,60 +225,15 @@ error_sentry.sentry_client.client.user_context({
 ```
 ErrorSentry also has an optional `sentry_report_limit` parameter that limits the number of times a specific error will
 be reported. Note that errors are counted based on their stack trace, under some conditions you will still receive
-multiple similar error reports. Error counts are tracked per-ErrorSentry object, they are not global.
+multiple similar error reports. Error counts are tracked per-ErrorSentry instance.
 
 
-# Kill Times
+# Debugging
 
-The time limit of tasks specified in TIME_LIMITS is for emailing you about tasks that take longer than expected to run.
-If a task takes over four times the time limit (see MAX_TIME_MULTIPLIER), the process of that task is killed. You can
-specify your own custom kill time by passing in param `kill_time` to `run_tasks`. For example, here is an alternate
-`cron.py` that specifies custom kill times:
+There is also a debugging mode: the NullErrorHandler.  This class is a drop-in replacement for all usages of the
+ErrorHandler and ErrorSentry classes.  What does it do?  Absolutely nothing.  Just change an import as follows
+and errors will be raised as if the the ErrorHandler or ErrorSentry were not present:
 
-```python
-from sys import argv
-from cronutils import run_tasks
+`from cronutils.error_handler import NullErrorHandler as ErrorHandler`
 
-FIVE_MINUTES = "five_minutes"
-HOURLY = "hourly"
-FOUR_HOURLY = "four_hourly"
-DAILY = "daily"
-WEEKLY = "weekly"
-MONTHLY = "monthly"
-
-TASKS = {
-    FIVE_MINUTES: [],
-    HOURLY: [],
-    FOUR_HOURLY: [],
-    DAILY: [],
-    WEEKLY: [],
-    MONTHLY: [],
-}
-
-TIME_LIMITS = {
-    FIVE_MINUTES: 180, # 3 minutes
-    HOURLY: 3600,      # 60 minutes
-    FOUR_HOURLY: 5400, # 1.5 hours
-    DAILY: 43200,      # 12 hours
-    WEEKLY: 86400,     # 1 day
-    MONTHLY: 259200,   # 3 days
-}
-
-KILL_TIMES = {
-    FIVE_MINUTES: 300, # 5 minutes
-    HOURLY: 3600, # 1 hour
-}
-
-
-if __name__ == "__main__":
-    if len(argv) <= 1:
-        raise Exception("Not enough arguments to cron\n")
-    elif argv[1] in TASKS:
-        cron_type = argv[1]
-        if cron_type in KILL_TIMES:
-            run_tasks(TASKS[cron_type], TIME_LIMITS[cron_type], cron_type, KILL_TIMES[cron_type])
-        else:
-            run_tasks(TASKS[cron_type], TIME_LIMITS[cron_type], cron_type)
-    else:
-        raise Exception("Invalid argument to cron\n")
-```
+`from cronutils.error_handler import NullErrorHandler as ErrorSentry`

--- a/README.md
+++ b/README.md
@@ -166,6 +166,10 @@ error_sentry.sentry_client.client.user_context({
     })
 
 ```
+ErrorSentry also has an optional `sentry_report_limit` parameter that limits the number of times a specific error will
+be reported. Note that errors are counted based on their stack trace, so there are conditions under which you will
+still receive multiple similar error reports. Error counts are per-ErrorSentry object, they not global.
+
 
 # Kill Times
 

--- a/README.md
+++ b/README.md
@@ -167,8 +167,8 @@ error_sentry.sentry_client.client.user_context({
 
 ```
 ErrorSentry also has an optional `sentry_report_limit` parameter that limits the number of times a specific error will
-be reported. Note that errors are counted based on their stack trace, so there are conditions under which you will
-still receive multiple similar error reports. Error counts are per-ErrorSentry object, they not global.
+be reported. Note that errors are counted based on their stack trace, under some conditions you will still receive
+multiple similar error reports. Error counts are tracked per-ErrorSentry object, they are not global.
 
 
 # Kill Times

--- a/cronutils/error_handler.py
+++ b/cronutils/error_handler.py
@@ -131,8 +131,20 @@ class ErrorSentry(ErrorHandler):
 
 
 class NullErrorHandler():
+
+    """
+    The NullErrorHandler class is for debugging your code.  Is a drop in replacement for any
+    use of an ErrorHandler or ErrorSentry.  What does it do?  Absolutely nothing.  Well, it
+    maintains syntax and attribute structure so that you don't have to think about it.
+    """
+
     def __init__(self, *args, **kwargs):
-        pass
+        """ Attach attributes found in ErrorHandler and ErrorSentry, provides correct defaults. """
+        self.errors = {}
+        self.descriptor = kwargs.get('descriptor', None)
+        self.data = None
+        self.data_limit = kwargs.get('data_limit', 100)
+        self.sentry_report_limit = kwargs.get('sentry_report_limit', 0)
     
     def __call__(self, data=None):
         return self

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ if sys.version < '2.5':
 
 setup(
     name = "cronutils",
-    version = "0.2.2",
+    version = "0.2.3",
     packages = find_packages(),
     
     author = "Zagaran, Inc.",
@@ -42,7 +42,9 @@ setup(
     license = "MIT",
     keywords = "cron crontab task error handling",
     url = "https://github.com/zagaran/cronutils",
-    install_requires = ["raven >= 5.32.0", "future == 0.18.2"],
+    install_requires = [
+        "raven >= 6.10.0", "future == 0.18.2"
+    ],
     classifiers = [
                  "Development Status :: 4 - Beta",
                  "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
These commits add a `sentry_report_limit` parameter to the ErrorSentry.
This has been tested in production on beiwe-backend, reduces error spam by orders of magnitude.

Other changes include:
Factoring out the code for formatting a stack trace key in the error handler so that the ErrorSentry code can use it.

Updated and added documentation.

Improved the NullErrrorHandler so that it can be dropped directly into spots where ErrorHandlers/ErrorSentries without needing to rewriting constructors, allowing
`from cronutils.error_handler import NullErrorHandler as ErrorHandler` 
and 
`from cronutils.error_handler import NullErrorHandler as ErrorSentry`